### PR TITLE
[fontname.py] updated the name table definition formats

### DIFF
--- a/scripts/fontname.py
+++ b/scripts/fontname.py
@@ -25,53 +25,80 @@ import os
 from fontTools import ttLib
 from fontTools.misc.py23 import tounicode, unicode
 
+
 def main(argv):
     # command argument tests
     print(" ")
     if len(argv) < 2:
-        sys.stderr.write("[fontname.py] ERROR: you did not include enough arguments to the script." + os.linesep)
-        sys.stderr.write("Usage: python fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>" + os.linesep)
+        sys.stderr.write(
+            "[fontname.py] ERROR: you did not include enough arguments to the script."
+            + os.linesep
+        )
+        sys.stderr.write(
+            "Usage: python fontname.py [FONT FAMILY NAME] [FONT PATH 1] <FONT PATH ...>"
+            + os.linesep
+        )
         sys.exit(1)
 
     # begin parsing command line arguments
     try:
         font_name = tounicode(argv[0])  # the first argument is the new typeface name
     except UnicodeDecodeError as e:
-        sys.stderr.write("[fontname.py] ERROR: Unable to convert argument to Unicode. " + unicode(e) + os.linesep)
+        sys.stderr.write(
+            "[fontname.py] ERROR: Unable to convert argument to Unicode. "
+            + unicode(e)
+            + os.linesep
+        )
         sys.exit(1)
 
-    font_path_list = argv[1:]  # all remaining arguments on command line are file paths to fonts
+    font_path_list = argv[
+        1:
+    ]  # all remaining arguments on command line are file paths to fonts
 
     # iterate through all paths provided on command line and rename to `font_name` defined by user
     for font_path in font_path_list:
         # test for existence of font file on requested file path
-        if file_exists(font_path):
-            pass  # do nothing, it is there
-        else:
-            sys.stderr.write("[fontname.py] ERROR: the path '" + font_path +"' does not appear to be a valid file path." + os.linesep)
+        if not file_exists(font_path):
+            sys.stderr.write(
+                "[fontname.py] ERROR: the path '"
+                + font_path
+                + "' does not appear to be a valid file path."
+                + os.linesep
+            )
             sys.exit(1)
 
         tt = ttLib.TTFont(font_path)
-        namerecord_list = tt['name'].names
+        namerecord_list = tt["name"].names
         variant = ""
 
         # determine font variant for this file path from name record nameID 2
         for record in namerecord_list:
             if record.nameID == 2:
-                variant = record.toUnicode()  # cast to str type in Py 3, unicode type in Py 2
+                variant = (
+                    record.toUnicode()
+                )  # cast to str type in Py 3, unicode type in Py 2
                 break
 
         # test that a variant name was found in the OpenType tables of the font
         if len(variant) == 0:
-            sys.stderr.write("[fontname.py] Unable to detect the font variant from the OpenType name table in '" + font_path + "'." + os.linesep)
+            sys.stderr.write(
+                "[fontname.py] Unable to detect the font variant from the OpenType name table in '"
+                + font_path
+                + "'."
+                + os.linesep
+            )
             sys.stderr.write("Unable to complete execution of the script.")
             sys.exit(1)
         else:
-            nospaces_font_name = font_name.replace(" ", "")   # used for the Postscript name in the name table (no spaces allowed)
-
-            nameID1_string = font_name                            # font family name
-            nameID4_string = font_name + " " + variant            # full font name
-            nameID6_string = nospaces_font_name + "-" + variant   # Postscript name (no spaces allowed, dash delimited)
+            # used for the Postscript name in the name table (no spaces allowed)
+            postscript_font_name = font_name.replace(" ", "")
+            # font family name
+            nameID1_string = font_name
+            # full font name
+            nameID4_string = font_name + " " + variant
+            # Postscript name
+            # - no spaces allowed in family name or the PostScript suffix. should be dash delimited
+            nameID6_string = postscript_font_name + "-" + variant.replace(" ", "")
 
             # modify the opentype table data in memory with updated values
             for record in namerecord_list:
@@ -85,22 +112,34 @@ def main(argv):
         # write changes to the font file
         try:
             tt.save(font_path)
-            print("[OK] Updated '" + font_path + "' with the name '" + nameID4_string + "'")
+            print(
+                "[OK] Updated '"
+                + font_path
+                + "' with the name '"
+                + nameID4_string
+                + "'"
+            )
         except Exception as e:
-            sys.stderr.write("[fontname.py] ERROR: unable to write new name to OpenType tables for '" + font_path + "'." + os.linesep)
+            sys.stderr.write(
+                "[fontname.py] ERROR: unable to write new name to OpenType tables for '"
+                + font_path
+                + "'."
+                + os.linesep
+            )
             sys.stderr.write(unicode(e))
             sys.exit(1)
 
 
-
 # Utilities
+
 
 def file_exists(filepath):
     """Tests for existence of a file on the string filepath"""
-    if os.path.exists(filepath) and os.path.isfile(filepath):  # test that exists and is a file
+    if os.path.exists(filepath) and os.path.isfile(filepath):
         return True
     else:
         return False
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
This PR includes changes to the scripts/fontname.py Python script that include:

- modifications to correct the formatting of names for the OpenType name table records
- Python script formatting (automated `black` formatting changes)

These modifications make the script current with the v0.3.0 release of fontname.py in chrisimpkins/fontname.py.  [Changelog](https://github.com/chrissimpkins/fontname.py/blob/master/CHANGELOG.md)

